### PR TITLE
Add remote signer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ create your database schema:
 
 When loading the configuration, the process looks at the environment variable `PEPPERMINT_PROFILE`. If this variable is not set, the file `config.json` is loaded. If profile is set, the process looks for the file `config_{profile}.json`.
 
+To enable remote signer support, remove `privateKey` from `config.json` and configure `remoteSigner` with relavant settings.
+
 This version of Peppermint allows multiple instances of handlers to be configured via `config.json`. In the `handlers` section, one can add multiple instances of the same handler module with different arguments, under different names. The names specified here will be used as the handler names in the SQL commands.
 
 At this moment, to reduce complexity, handler modules are *not* auto-populated from the `operations` folder, but imported manually in `app.mjs` - so when adding new, custom handler modules, these need to be specifically imported and added to the `Handlers` object in that file.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ create your database schema:
 
 When loading the configuration, the process looks at the environment variable `PEPPERMINT_PROFILE`. If this variable is not set, the file `config.json` is loaded. If profile is set, the process looks for the file `config_{profile}.json`.
 
-To enable remote signer support, remove `privateKey` from `config.json` and configure `remoteSigner` with relavant settings.
+To enable remote signer support, remove `privateKey` from `config.json` and configure `remoteSigner` with relevant settings.
 
 This version of Peppermint allows multiple instances of handlers to be configured via `config.json`. In the `handlers` section, one can add multiple instances of the same handler module with different arguments, under different names. The names specified here will be used as the handler names in the SQL commands.
 

--- a/app.mjs
+++ b/app.mjs
@@ -1,6 +1,7 @@
 import { createRequire } from 'module'
 import { TezosToolkit, TezosOperationError } from '@taquito/taquito'
 import { InMemorySigner } from '@taquito/signer'
+import { RemoteSigner } from '@taquito/remote-signer';
 import { asyncExitHook } from 'exit-hook'
 
 import Queue from './queue.mjs'
@@ -21,17 +22,26 @@ require('console-stamp')(console);
 const config = ConfLoader();
 
 const get_signing_key = async function(config) {
-  try {
-    const signer = new InMemorySigner(config.privateKey);
-    return signer;
-  } catch (err) {
-    if (err.name == 'InvalidPassphraseError') {
-      const pass = await promptly.prompt('Passphrase: ', { silent: true });
-      const signer = InMemorySigner.fromSecretKey(config.privateKey, pass);
-      return signer;
-    } else {
-      throw(err);
-    }
+  if (config.privateKey) {
+	  try {
+		  const signer = new InMemorySigner(config.privateKey);
+		  return signer;
+	  } catch (err) {
+		  if (err.name == 'InvalidPassphraseError') {
+			  const pass = await promptly.prompt('Passphrase: ', { silent: true });
+			  const signer = InMemorySigner.fromSecretKey(config.privateKey, pass);
+			  return signer;
+		  } else {
+			  throw (err);
+		  }
+	  }
+  } else {
+	const signer = new RemoteSigner(
+		config.remoteSigner.pkh,
+		config.remoteSigner.rootUrl,
+		{ headers: config.remoteSigner.headers }
+	);
+	return signer;
   }
 }
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,6 +1,13 @@
 {
 	"batchSize": 110,
 	"confirmations": 1,
+	"remoteSigner": {
+		"pkh": "tz1somethingsomething",
+		"rootUrl": "http://127.0.0.1:8000",
+		"headers": {
+			"x-api-key": "supersecureapikey"
+		}
+	},
 	"privateKey": "edsksomethingsomething",
 	"rpcUrl": "https://ghostnet.ecadinfra.com/",
 	"pollingDelay": 10000,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.1",
 			"license": "MIT",
 			"dependencies": {
+				"@taquito/remote-signer": "^15.0.0",
 				"@taquito/signer": "^14.1.0",
 				"@taquito/taquito": "^14.1.0",
 				"console-stamp": "^3.0.3",
@@ -191,6 +192,119 @@
 				"@taquito/utils": "^14.1.0",
 				"bignumber.js": "^9.1.0",
 				"fast-json-stable-stringify": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@taquito/remote-signer": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/remote-signer/-/remote-signer-15.0.0.tgz",
+			"integrity": "sha512-pCWPYVcgtjeIFIPEVaeKOTtd1pqWozR9Ap4L6IglxR6IWluLhMeuCRCxI/sMWJOBaDY9598D8l8iyo8oU2+miQ==",
+			"dependencies": {
+				"@stablelib/blake2b": "^1.0.1",
+				"@stablelib/ed25519": "^1.0.3",
+				"@taquito/http-utils": "^15.0.0",
+				"@taquito/taquito": "^15.0.0",
+				"@taquito/utils": "^15.0.0",
+				"typedarray-to-buffer": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@taquito/remote-signer/node_modules/@taquito/http-utils": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-15.0.0.tgz",
+			"integrity": "sha512-caOofYWZzbxti1s1t3ObkRL4Ph8DpAWWY/staI1IiZJ/g/XX8FDtS71tE+IwBLXwH0kYqP0bNhTGPP04ebEHpQ==",
+			"dependencies": {
+				"@vespaiach/axios-fetch-adapter": "^0.3.1",
+				"axios": "^0.26.0"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@taquito/remote-signer/node_modules/@taquito/local-forging": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-15.0.0.tgz",
+			"integrity": "sha512-8QLut19U03Tsm59RjrSZOlLZx5mglQjQFt5No1VzWfNsXv7mytmn8SlvqFxyt8hyTlm1RM1NdJJ1oO1h1A/BRQ==",
+			"dependencies": {
+				"@taquito/utils": "^15.0.0",
+				"bignumber.js": "^9.1.0"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@taquito/remote-signer/node_modules/@taquito/michel-codec": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-15.0.0.tgz",
+			"integrity": "sha512-pfnrXVSkGeeVNx7MYHTeu79iU4lGynym/7+8QbD/O28LWob8PUrwpt+jaAxsVDdNOYtKz+LO1E4FpC348tHO6Q==",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@taquito/remote-signer/node_modules/@taquito/michelson-encoder": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-15.0.0.tgz",
+			"integrity": "sha512-TxmWCgZBuA7SrNPSN+xfeeovDGU5H5sXyXcgL3KwYfeILaWiWr1MbI9n8xV7ewJZSC9svor6/osz7Y04+TIpgw==",
+			"dependencies": {
+				"@taquito/rpc": "^15.0.0",
+				"@taquito/utils": "^15.0.0",
+				"bignumber.js": "^9.1.0",
+				"fast-json-stable-stringify": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@taquito/remote-signer/node_modules/@taquito/rpc": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-15.0.0.tgz",
+			"integrity": "sha512-z5oPSD2QDhLqU9scA4Pof2+DUaK9P3oDWeCqr6/JAOlt1DwDwYsHj84d4UVmpjP/DrTj4Sp1IyY7I9KpNNLlGQ==",
+			"dependencies": {
+				"@taquito/http-utils": "^15.0.0",
+				"@taquito/utils": "^15.0.0",
+				"bignumber.js": "^9.1.0"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@taquito/remote-signer/node_modules/@taquito/taquito": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-15.0.0.tgz",
+			"integrity": "sha512-pYs/hBbjapR/wN+gLhQQYEbL3D7WZXsR/+cb5oCN67vhKwyXkDuBJIEpWIoFGNcwJn0eGFGkUjfngE1bUyMypA==",
+			"hasInstallScript": true,
+			"dependencies": {
+				"@taquito/http-utils": "^15.0.0",
+				"@taquito/local-forging": "^15.0.0",
+				"@taquito/michel-codec": "^15.0.0",
+				"@taquito/michelson-encoder": "^15.0.0",
+				"@taquito/rpc": "^15.0.0",
+				"@taquito/utils": "^15.0.0",
+				"bignumber.js": "^9.1.0",
+				"rxjs": "^6.6.3"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@taquito/remote-signer/node_modules/@taquito/utils": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-15.0.0.tgz",
+			"integrity": "sha512-15Eq3YarC3HuZY8fmAEmtZaFglMIHjRVeR7l4fd8NJK6EdDZydJ00o40JMof9mhSy6A5atm15IHLD5sfdfx5lg==",
+			"dependencies": {
+				"@stablelib/blake2b": "^1.0.1",
+				"@stablelib/ed25519": "^1.0.3",
+				"@types/bs58check": "^2.1.0",
+				"bignumber.js": "^9.1.0",
+				"blakejs": "^1.2.1",
+				"bs58check": "^2.1.2",
+				"buffer": "^6.0.3",
+				"elliptic": "^6.5.4",
+				"typedarray-to-buffer": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=6.0.0"
@@ -1087,6 +1201,96 @@
 				"@taquito/utils": "^14.1.0",
 				"bignumber.js": "^9.1.0",
 				"fast-json-stable-stringify": "^2.1.0"
+			}
+		},
+		"@taquito/remote-signer": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@taquito/remote-signer/-/remote-signer-15.0.0.tgz",
+			"integrity": "sha512-pCWPYVcgtjeIFIPEVaeKOTtd1pqWozR9Ap4L6IglxR6IWluLhMeuCRCxI/sMWJOBaDY9598D8l8iyo8oU2+miQ==",
+			"requires": {
+				"@stablelib/blake2b": "^1.0.1",
+				"@stablelib/ed25519": "^1.0.3",
+				"@taquito/http-utils": "^15.0.0",
+				"@taquito/taquito": "^15.0.0",
+				"@taquito/utils": "^15.0.0",
+				"typedarray-to-buffer": "^4.0.0"
+			},
+			"dependencies": {
+				"@taquito/http-utils": {
+					"version": "15.0.0",
+					"resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-15.0.0.tgz",
+					"integrity": "sha512-caOofYWZzbxti1s1t3ObkRL4Ph8DpAWWY/staI1IiZJ/g/XX8FDtS71tE+IwBLXwH0kYqP0bNhTGPP04ebEHpQ==",
+					"requires": {
+						"@vespaiach/axios-fetch-adapter": "^0.3.1",
+						"axios": "^0.26.0"
+					}
+				},
+				"@taquito/local-forging": {
+					"version": "15.0.0",
+					"resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-15.0.0.tgz",
+					"integrity": "sha512-8QLut19U03Tsm59RjrSZOlLZx5mglQjQFt5No1VzWfNsXv7mytmn8SlvqFxyt8hyTlm1RM1NdJJ1oO1h1A/BRQ==",
+					"requires": {
+						"@taquito/utils": "^15.0.0",
+						"bignumber.js": "^9.1.0"
+					}
+				},
+				"@taquito/michel-codec": {
+					"version": "15.0.0",
+					"resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-15.0.0.tgz",
+					"integrity": "sha512-pfnrXVSkGeeVNx7MYHTeu79iU4lGynym/7+8QbD/O28LWob8PUrwpt+jaAxsVDdNOYtKz+LO1E4FpC348tHO6Q=="
+				},
+				"@taquito/michelson-encoder": {
+					"version": "15.0.0",
+					"resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-15.0.0.tgz",
+					"integrity": "sha512-TxmWCgZBuA7SrNPSN+xfeeovDGU5H5sXyXcgL3KwYfeILaWiWr1MbI9n8xV7ewJZSC9svor6/osz7Y04+TIpgw==",
+					"requires": {
+						"@taquito/rpc": "^15.0.0",
+						"@taquito/utils": "^15.0.0",
+						"bignumber.js": "^9.1.0",
+						"fast-json-stable-stringify": "^2.1.0"
+					}
+				},
+				"@taquito/rpc": {
+					"version": "15.0.0",
+					"resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-15.0.0.tgz",
+					"integrity": "sha512-z5oPSD2QDhLqU9scA4Pof2+DUaK9P3oDWeCqr6/JAOlt1DwDwYsHj84d4UVmpjP/DrTj4Sp1IyY7I9KpNNLlGQ==",
+					"requires": {
+						"@taquito/http-utils": "^15.0.0",
+						"@taquito/utils": "^15.0.0",
+						"bignumber.js": "^9.1.0"
+					}
+				},
+				"@taquito/taquito": {
+					"version": "15.0.0",
+					"resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-15.0.0.tgz",
+					"integrity": "sha512-pYs/hBbjapR/wN+gLhQQYEbL3D7WZXsR/+cb5oCN67vhKwyXkDuBJIEpWIoFGNcwJn0eGFGkUjfngE1bUyMypA==",
+					"requires": {
+						"@taquito/http-utils": "^15.0.0",
+						"@taquito/local-forging": "^15.0.0",
+						"@taquito/michel-codec": "^15.0.0",
+						"@taquito/michelson-encoder": "^15.0.0",
+						"@taquito/rpc": "^15.0.0",
+						"@taquito/utils": "^15.0.0",
+						"bignumber.js": "^9.1.0",
+						"rxjs": "^6.6.3"
+					}
+				},
+				"@taquito/utils": {
+					"version": "15.0.0",
+					"resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-15.0.0.tgz",
+					"integrity": "sha512-15Eq3YarC3HuZY8fmAEmtZaFglMIHjRVeR7l4fd8NJK6EdDZydJ00o40JMof9mhSy6A5atm15IHLD5sfdfx5lg==",
+					"requires": {
+						"@stablelib/blake2b": "^1.0.1",
+						"@stablelib/ed25519": "^1.0.3",
+						"@types/bs58check": "^2.1.0",
+						"bignumber.js": "^9.1.0",
+						"blakejs": "^1.2.1",
+						"bs58check": "^2.1.2",
+						"buffer": "^6.0.3",
+						"elliptic": "^6.5.4",
+						"typedarray-to-buffer": "^4.0.0"
+					}
+				}
 			}
 		},
 		"@taquito/rpc": {

--- a/package.json
+++ b/package.json
@@ -10,13 +10,14 @@
 	"author": "",
 	"license": "MIT",
 	"dependencies": {
+		"@taquito/remote-signer": "^15.0.0",
 		"@taquito/signer": "^14.1.0",
 		"@taquito/taquito": "^14.1.0",
 		"console-stamp": "^3.0.3",
 		"exit-hook": "^3.1.2",
 		"pg": "^8.7.1",
 		"promptly": "^3.2.0",
-	  "string-hex": "^1.0.0",
+		"string-hex": "^1.0.0",
 		"uuid": "^9.0.0"
 	}
 }


### PR DESCRIPTION
Peppermint will still use the in-memory signer as default when `privateKey` is specified in config.

To enable the remote signer, remove `privateKey` from `config.json` and configure `remoteSigner` with relevant settings.